### PR TITLE
リザルト画面を三つに増やしました。

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,4 +1,10 @@
 class ResultsController < ApplicationController
-  def index
+  def color_rock_paper_sicissors
+  end
+
+  def memory_square
+  end
+
+  def number_master
   end
 end

--- a/app/views/results/color_rock_paper_sicissors.html.erb
+++ b/app/views/results/color_rock_paper_sicissors.html.erb
@@ -1,0 +1,28 @@
+<div class="results-page__top">
+  <div class="result-page__left-side">
+    <%= image_tag "result-page-images/Vector.svg", alt: "score背景", class: "score-background" %>
+
+    <div class="result-page__score-name">score</div>
+    <div class="result-page__score"></div>
+    <div class="result-page__score-display">00.00秒!</div>
+
+    <div class="result-page__Registration-form">
+      <div class="result-page__username">記録を登録しますか？</div>
+      <div class="result-page__form">
+        <input type="text" placeholder="ニックネーム入力" class="result-page__name-form">
+        <input type="submit" name="commit" value="登録" data-disable-with="登録" class="result-page__registration-button">
+      </div>
+    </div>
+
+    <div class="result-page__container">
+      <%= image_tag "result-page-images/Frame 89 (1).svg", alt:"フレーム画像", class:"result-page__frame" %>
+      <%= link_to "リトライする", games_color_rock_paper_sicissors_path, class: "result-page__retry-button" %>
+      <%= link_to "トップへ戻る", root_path, class: "result-page__back-to-home-button" %>
+    </div>
+  </div>
+
+  <div class="result-page__right-side">
+    <%= image_tag "result-page-images/e1140_1 1.svg", alt:"リザルト画面メッセージ", class:"result-page__right-message" %>
+    <%= image_tag "result-page-images/undraw_winners_re_wr1l 1.svg", alt:"リザルト画面のイラスト", class:"result-page__right-image" %>
+  </div>
+</div>

--- a/app/views/results/memory_square.html.erb
+++ b/app/views/results/memory_square.html.erb
@@ -1,9 +1,11 @@
 <div class="results-page__top">
   <div class="result-page__left-side">
     <%= image_tag "result-page-images/Vector.svg", alt: "score背景", class: "score-background" %>
-      <div class="result-page__score-name">score</div>
+
+    <div class="result-page__score-name">score</div>
     <div class="result-page__score"></div>
-      <div class="result-page__score-display">00.00秒!</div>
+    <div class="result-page__score-display">00.00秒!</div>
+
     <div class="result-page__Registration-form">
       <div class="result-page__username">記録を登録しますか？</div>
       <div class="result-page__form">
@@ -11,17 +13,17 @@
         <input type="submit" name="commit" value="登録" data-disable-with="登録" class="result-page__registration-button">
       </div>
     </div>
+
     <div class="result-page__container">
-      <%= image_tag "result-page-images/Frame 89 (1).svg", alt:"フレーム画像", class:"result-page__frame"%>
-      <%= link_to "リトライする", games_color_rock_paper_sicissors_path, class: "result-page__retry-button" %>
+      <%= image_tag "result-page-images/Frame 89 (1).svg", alt:"フレーム画像", class:"result-page__frame" %>
+      <%= link_to "リトライする", games_memory_square_path, class: "result-page__retry-button" %>
       <%= link_to "トップへ戻る", root_path, class: "result-page__back-to-home-button" %>
     </div>
   </div>
-    
+
   <div class="result-page__right-side">
-    <%= image_tag "result-page-images/e1140_1 1.svg", alt:"リザルト画面メッセージ", class:"result-page__right-message"%>
-    <%= image_tag "result-page-images/undraw_winners_re_wr1l 1.svg", alt:"リザルト画面のイラスト", class:"result-page__right-image"%>
-    
+    <%= image_tag "result-page-images/e1140_1 1.svg", alt:"リザルト画面メッセージ", class:"result-page__right-message" %>
+    <%= image_tag "result-page-images/undraw_winners_re_wr1l 1.svg", alt:"リザルト画面のイラスト", class:"result-page__right-image" %>
   </div>
 </div>
 

--- a/app/views/results/number_master.html.erb
+++ b/app/views/results/number_master.html.erb
@@ -1,0 +1,28 @@
+<div class="results-page__top">
+  <div class="result-page__left-side">
+    <%= image_tag "result-page-images/Vector.svg", alt: "score背景", class: "score-background" %>
+
+    <div class="result-page__score-name">score</div>
+    <div class="result-page__score"></div>
+    <div class="result-page__score-display">00.00秒!</div>
+
+    <div class="result-page__Registration-form">
+      <div class="result-page__username">記録を登録しますか？</div>
+      <div class="result-page__form">
+        <input type="text" placeholder="ニックネーム入力" class="result-page__name-form">
+        <input type="submit" name="commit" value="登録" data-disable-with="登録" class="result-page__registration-button">
+      </div>
+    </div>
+
+    <div class="result-page__container">
+      <%= image_tag "result-page-images/Frame 89 (1).svg", alt:"フレーム画像", class:"result-page__frame" %>
+      <%= link_to "リトライする", games_number_master_path, class: "result-page__retry-button" %>
+      <%= link_to "トップへ戻る", root_path, class: "result-page__back-to-home-button" %>
+    </div>
+  </div>
+
+  <div class="result-page__right-side">
+    <%= image_tag "result-page-images/e1140_1 1.svg", alt:"リザルト画面メッセージ", class:"result-page__right-message" %>
+    <%= image_tag "result-page-images/undraw_winners_re_wr1l 1.svg", alt:"リザルト画面のイラスト", class:"result-page__right-image" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,7 @@ Rails.application.routes.draw do
   get 'games/number_master'
   get 'games/reverse_colors'
   get 'games/fit_the_shape'
-  get 'results/index'
+  get 'results/color_rock_paper_sicissors'
+  get 'results/memory_square'
+  get 'results/number_master'
 end


### PR DESCRIPTION
# What
リザルト画面を三つに増やし、それに伴うルーティングとコントローラーの変更のコード

# Why
一つのリザルト画面を複数人で修正することになるのでコンフリクトが起こりやすくなる。
リザルト画面が一つのままだと、一つのリザルト画面に対する条件分岐が多くなり、実装に時間がかかる。
という上記の問題を避けるため。